### PR TITLE
Find Users with Browse Permission

### DIFF
--- a/cloud/role.go
+++ b/cloud/role.go
@@ -13,11 +13,21 @@ type RoleService service
 
 // Role represents a Jira product role
 type Role struct {
-	Self        string   `json:"self" structs:"self"`
-	Name        string   `json:"name" structs:"name"`
-	ID          int      `json:"id" structs:"id"`
-	Description string   `json:"description" structs:"description"`
-	Actors      []*Actor `json:"actors" structs:"actors"`
+	Self        string     `json:"self" structs:"self"`
+	Name        string     `json:"name" structs:"name"`
+	ID          int        `json:"id" structs:"id"`
+	Description string     `json:"description" structs:"description"`
+	Actors      []*Actor   `json:"actors" structs:"actors"`
+	Scope       *RoleScope `json:"scope" structs:"scope"`
+}
+
+type RoleScope struct {
+	Type    string            `json:"type" structs:"type"`
+	Project *RoleScopeProject `json:"project" structs:"project"`
+}
+
+type RoleScopeProject struct {
+	ID string `json:"id" structs:"id"`
 }
 
 // Actor represents a Jira actor

--- a/cloud/searching.go
+++ b/cloud/searching.go
@@ -54,6 +54,13 @@ func WithProjectId(projectId string) searchF {
 	}
 }
 
+func WithProjectKey(projectKey string) searchF {
+	return func(s search) search {
+		s = append(s, searchParam{name: "projectKey", value: projectKey})
+		return s
+	}
+}
+
 func WithStatusCategory(statusCategory string) searchF {
 	return func(s search) search {
 		s = append(s, searchParam{name: "statusCategory", value: statusCategory})


### PR DESCRIPTION
Adds the FindUsersWithBrowsePermission endpoint to the UsersService. This endpoint lets us list users that have the ability to browse issues for a given project.

Also adds the models to fetch role scopes.